### PR TITLE
Consumers of this library can now cache the checkpointer object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+vendor
+
 # osx / sshfs
 ._*
 .DS_Store

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -59,7 +59,7 @@ func (srp *SampleRecordProcessor) ProcessRecords(records []kcl.Record) error {
 func (srp *SampleRecordProcessor) Shutdown(reason string) error {
 	if reason == "TERMINATE" {
 		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
-		srp.checkpoint(nil, nil)
+		srp.checkpointer.Shutdown()
 	} else {
 		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Will not checkpoint.\n")
 	}

--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sync"
 )
 
 type RecordProcessor interface {
@@ -23,6 +24,8 @@ func (ce CheckpointError) Error() string {
 }
 
 type Checkpointer struct {
+	mux sync.Mutex
+
 	ioHandler ioHandler
 }
 
@@ -39,6 +42,9 @@ func (c *Checkpointer) getAction() (interface{}, error) {
 }
 
 func (c *Checkpointer) Checkpoint(sequenceNumber *string, subSequenceNumber *int) error {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
 	c.ioHandler.writeAction(ActionCheckpoint{
 		Action:            "checkpoint",
 		SequenceNumber:    sequenceNumber,
@@ -62,7 +68,6 @@ func (c *Checkpointer) Checkpoint(sequenceNumber *string, subSequenceNumber *int
 		}
 	}
 	return nil
-
 }
 
 type ioHandler struct {

--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -108,6 +108,10 @@ func (c *Checkpointer) CheckpointWithRetry(
 	return nil
 }
 
+func (c *Checkpointer) Shutdown() {
+	c.CheckpointWithRetry(nil, nil, 5)
+}
+
 type ioHandler struct {
 	inputFile  io.Reader
 	outputFile io.Writer


### PR DESCRIPTION
A `Checkpointer` struct is passed to the `initialize` function.  This makes it clear that consumers should save `checkpointer` and that it should feel free to use it when ever it'd like.  Previously a reference to `checkpointer` could not be saved by library consumers, which made it more difficult to save progress.