### PR TITLE
Updated syslogparser library and added unit tests

### DIFF
--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -203,6 +203,12 @@ type ParseAndEnhanceSpec struct {
 }
 
 func TestParseAndEnhance(t *testing.T) {
+	logTime2, err := time.Parse(time.RFC3339, "2017-04-05T21:57:46+00:00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logTime2 = logTime2.UTC()
+
 	// timestamp in Rsyslog_FileFormat
 	logTime3, err := time.Parse(RFC3339Micro, "2017-04-05T21:57:46.794862+00:00")
 	if err != nil {
@@ -416,6 +422,22 @@ func TestParseAndEnhance(t *testing.T) {
 				"kv__source":     "a",
 			},
 			ExpectedError: nil,
+		},
+		ParseAndEnhanceSpec{
+			Title: "Log with timestamp time.RFC3339 format",
+			Input: ParseAndEnhanceInput{
+				Line: `2017-04-05T21:57:46+00:00 mongo-docker-pipeline-r10-4 diamond[24099] ` +
+					`Signal Received: 15`,
+				RenameESReservedFields: true,
+				MinimumTimestamp:       time.Now().Add(-100 * time.Hour * 24 * 365), // year 2117
+			},
+			ExpectedOutput: map[string]interface{}{
+				"env":         "deploy-env",
+				"hostname":    "mongo-docker-pipeline-r10-4",
+				"programname": "diamond",
+				"rawlog":      "Signal Received: 15",
+				"timestamp":   logTime2,
+			},
 		},
 	}
 	for _, spec := range specs {

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 6da9731518797a7e339144f126af589f72f860bee154b0f2a552f91d2bc01bab
-updated: 2017-07-18T02:00:59.747262097Z
+hash: 6cc2c955c4d70fea747e0056aa63e8fe6a0f8d8c9baca20cf3a5a34d0c55b1fb
+updated: 2017-08-16T20:57:02.3853046Z
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: b73b028e599fa9176687c70b8f9cafbe57c27d20
+  version: 819b71cf8430e434c1eee7e7e8b0f2b8870be899
   subpackages:
   - aws
   - aws/session
@@ -12,7 +12,7 @@ imports:
   subpackages:
   - writer
 - name: github.com/Clever/syslogparser
-  version: 93ab95f7ff16c9ef1f2d09bc37c0a0c31bad98ea
+  version: fb28ad3e4340c046323b7beba685a72fd12ecbe8
   subpackages:
   - rfc3164
 - name: github.com/jeromer/syslogparser

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,7 @@ import:
   subpackages:
   - writer
 - package: github.com/Clever/syslogparser
+  version: master
   subpackages:
   - rfc3164
 - package: github.com/aws/aws-sdk-go
@@ -14,9 +15,9 @@ import:
 - package: golang.org/x/time
   subpackages:
   - rate
+- package: gopkg.in/Clever/kayvee-go.v6
+  version: ^6.0.0
 testImport:
 - package: github.com/stretchr/testify
   subpackages:
   - assert
-- package: gopkg.in/Clever/kayvee-go.v6
-  version: ^6.0.0


### PR DESCRIPTION
Several machines in prod are emitting logs with this style of timestamps.

Related: https://github.com/clever/syslogparser/pull/1