### PR TITLE
write errors to stderr, failed log lines to file

### DIFF
--- a/batchconsumer/batchermanager.go
+++ b/batchconsumer/batchermanager.go
@@ -187,7 +187,13 @@ func (b *batcherManager) startMessageHandler(
 					batcher.AddMessage(tmp.msg, tmp.pair)
 				} else if err != nil {
 					lg.ErrorD("add-message", kv.M{
-						"err": err.Error(), "msg": string(tmp.msg), "tag": tmp.tag,
+						"err": err.Error(),
+						"tag": tmp.tag,
+					})
+					b.failedLogsFile.ErrorD("add-message", kv.M{
+						"err": err.Error(),
+						"msg": string(tmp.msg),
+						"tag": tmp.tag,
 					})
 				}
 				stats.Counter("msg-batched", 1)

--- a/batchconsumer/checkpointmanager.go
+++ b/batchconsumer/checkpointmanager.go
@@ -3,15 +3,11 @@ package batchconsumer
 import (
 	"time"
 
-	kv "gopkg.in/Clever/kayvee-go.v6/logger"
-
 	"github.com/Clever/amazon-kinesis-client-go/batchconsumer/stats"
 	"github.com/Clever/amazon-kinesis-client-go/kcl"
 )
 
 type checkpointManager struct {
-	log kv.KayveeLogger
-
 	checkpointFreq time.Duration
 
 	checkpoint chan kcl.SequencePair
@@ -19,12 +15,8 @@ type checkpointManager struct {
 	shutdown chan chan<- struct{}
 }
 
-func newCheckpointManager(
-	checkpointer kcl.Checkpointer, checkpointFreq time.Duration, log kv.KayveeLogger,
-) *checkpointManager {
+func newCheckpointManager(checkpointer kcl.Checkpointer, checkpointFreq time.Duration) *checkpointManager {
 	cm := &checkpointManager{
-		log: log,
-
 		checkpointFreq: checkpointFreq,
 
 		checkpoint: make(chan kcl.SequencePair),

--- a/batchconsumer/consumer.go
+++ b/batchconsumer/consumer.go
@@ -13,9 +13,6 @@ import (
 
 // Config used for BatchConsumer constructor.  Any empty fields are populated with defaults.
 type Config struct {
-	// Logger for logging info / error logs.
-	Logger logger.KayveeLogger
-
 	// FailedLogsFile is where logs that failed to process are written.
 	FailedLogsFile string
 
@@ -42,10 +39,6 @@ type BatchConsumer struct {
 }
 
 func withDefaults(config Config) Config {
-	if config.Logger == nil {
-		config.Logger = logger.New("amazon-kinesis-client-go")
-	}
-
 	if config.FailedLogsFile == "" {
 		config.FailedLogsFile = "/tmp/kcl-" + time.Now().Format(time.RFC3339)
 	}
@@ -85,10 +78,10 @@ func NewBatchConsumerFromFiles(
 	if err != nil {
 		log.Fatalf("Unable to create log file: %s", err.Error())
 	}
-	failedLogsFile := logger.New("amazon-kinesis-client-go")
+	failedLogsFile := logger.New("amazon-kinesis-client-go/batchconsumer")
 	failedLogsFile.SetOutput(file)
 
-	wrt := NewBatchedWriter(config, sender, config.Logger, failedLogsFile)
+	wrt := NewBatchedWriter(config, sender, failedLogsFile)
 	kclProcess := kcl.New(input, output, errFile, wrt)
 
 	return &BatchConsumer{

--- a/batchconsumer/writer_test.go
+++ b/batchconsumer/writer_test.go
@@ -142,7 +142,7 @@ func TestProcessRecordsIgnoredMessages(t *testing.T) {
 	})
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 
-	wrt := NewBatchedWriter(mockconfig, ignoringSender{}, mocklog)
+	wrt := NewBatchedWriter(mockconfig, ignoringSender{}, mocklog, mocklog)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -173,7 +173,7 @@ func TestProcessRecordsSingleBatchBasic(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -220,7 +220,7 @@ func TestProcessRecordsMutliBatchBasic(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -278,7 +278,7 @@ func TestProcessRecordsMutliBatchWithIgnores(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -355,7 +355,7 @@ func TestStaggeredCheckpionting(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{

--- a/batchconsumer/writer_test.go
+++ b/batchconsumer/writer_test.go
@@ -135,14 +135,14 @@ func encode(str string) string {
 func TestProcessRecordsIgnoredMessages(t *testing.T) {
 	assert := assert.New(t)
 
-	mocklog := logger.New("testing")
+	mockFailedLogsFile := logger.New("testing")
 	mockconfig := withDefaults(Config{
 		BatchInterval:  10 * time.Millisecond,
 		CheckpointFreq: 20 * time.Millisecond,
 	})
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 
-	wrt := NewBatchedWriter(mockconfig, ignoringSender{}, mocklog, mocklog)
+	wrt := NewBatchedWriter(mockconfig, ignoringSender{}, mockFailedLogsFile)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -165,7 +165,7 @@ func TestProcessRecordsIgnoredMessages(t *testing.T) {
 func TestProcessRecordsSingleBatchBasic(t *testing.T) {
 	assert := assert.New(t)
 
-	mocklog := logger.New("testing")
+	mockFailedLogsFile := logger.New("testing")
 	mockconfig := withDefaults(Config{
 		BatchCount:     2,
 		CheckpointFreq: 1, // Don't throttle checks points
@@ -173,7 +173,7 @@ func TestProcessRecordsSingleBatchBasic(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mockFailedLogsFile)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -212,7 +212,7 @@ func TestProcessRecordsSingleBatchBasic(t *testing.T) {
 func TestProcessRecordsMutliBatchBasic(t *testing.T) {
 	assert := assert.New(t)
 
-	mocklog := logger.New("testing")
+	mockFailedLogsFile := logger.New("testing")
 	mockconfig := withDefaults(Config{
 		BatchInterval:  100 * time.Millisecond,
 		CheckpointFreq: 200 * time.Millisecond,
@@ -220,7 +220,7 @@ func TestProcessRecordsMutliBatchBasic(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mockFailedLogsFile)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -270,7 +270,7 @@ func TestProcessRecordsMutliBatchBasic(t *testing.T) {
 func TestProcessRecordsMutliBatchWithIgnores(t *testing.T) {
 	assert := assert.New(t)
 
-	mocklog := logger.New("testing")
+	mockFailedLogsFile := logger.New("testing")
 	mockconfig := withDefaults(Config{
 		BatchInterval:  100 * time.Millisecond,
 		CheckpointFreq: 200 * time.Millisecond,
@@ -278,7 +278,7 @@ func TestProcessRecordsMutliBatchWithIgnores(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mockFailedLogsFile)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{
@@ -346,7 +346,7 @@ func TestProcessRecordsMutliBatchWithIgnores(t *testing.T) {
 func TestStaggeredCheckpionting(t *testing.T) {
 	assert := assert.New(t)
 
-	mocklog := logger.New("testing")
+	mockFailedLogsFile := logger.New("testing")
 	mockconfig := withDefaults(Config{
 		BatchCount:     2,
 		BatchInterval:  100 * time.Millisecond,
@@ -355,7 +355,7 @@ func TestStaggeredCheckpionting(t *testing.T) {
 	mockcheckpointer := NewMockCheckpointer(5 * time.Second)
 	mocksender := NewMsgAsTagSender()
 
-	wrt := NewBatchedWriter(mockconfig, mocksender, mocklog, mocklog)
+	wrt := NewBatchedWriter(mockconfig, mocksender, mockFailedLogsFile)
 	wrt.Initialize("test-shard", mockcheckpointer)
 
 	err := wrt.ProcessRecords([]kcl.Record{

--- a/cmd/batchconsumer/main.go
+++ b/cmd/batchconsumer/main.go
@@ -14,7 +14,6 @@ func main() {
 		BatchInterval:  10 * time.Second,
 		BatchCount:     500,
 		BatchSize:      4 * 1024 * 1024, // 4Mb
-		Logger:         logger.New("amazon-kinesis-client-go"),
 		FailedLogsFile: "/tmp/example-kcl-consumer",
 	}
 

--- a/cmd/batchconsumer/main.go
+++ b/cmd/batchconsumer/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"time"
 
 	"gopkg.in/Clever/kayvee-go.v6/logger"
@@ -11,30 +9,16 @@ import (
 	kbc "github.com/Clever/amazon-kinesis-client-go/batchconsumer"
 )
 
-func createDummyOutput() (logger.KayveeLogger, *os.File) {
-	file, err := os.OpenFile("/tmp/example-kcl-output", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if err != nil {
-		log.Fatalf("Unable to create log file: %s", err.Error())
-	}
-
-	kvlog := logger.New("amazon-kinesis-client-go")
-	kvlog.SetOutput(file)
-
-	return kvlog, file
-}
-
 func main() {
 	config := kbc.Config{
-		BatchInterval: 10 * time.Second,
-		BatchCount:    500,
-		BatchSize:     4 * 1024 * 1024, // 4Mb
-		LogFile:       "/tmp/example-kcl-consumer",
+		BatchInterval:  10 * time.Second,
+		BatchCount:     500,
+		BatchSize:      4 * 1024 * 1024, // 4Mb
+		Logger:         logger.New("amazon-kinesis-client-go"),
+		FailedLogsFile: "/tmp/example-kcl-consumer",
 	}
 
-	output, file := createDummyOutput()
-	defer file.Close()
-
-	sender := &exampleSender{output: output}
+	sender := &exampleSender{output: logger.New("fake-output")}
 	consumer := kbc.NewBatchConsumer(config, sender)
 	consumer.Start()
 }

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 0.1.4
+GOLANG_MK_VERSION := 0.1.5
 
 SHELL := /bin/bash
 .PHONY: golang-godep-vendor golang-test-deps $(GODEP)
@@ -10,13 +10,21 @@ SHELL := /bin/bash
 GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
 
 # This block checks and confirms that the proper Go toolchain version is installed.
+# It uses ^ matching in the semver sense -- you can be ahead by a minor
+# version, but not a major version (patch is ignored).
 # arg1: golang version
 define golang-version-check
-GOVERSION := $(shell go version | grep $(1))
-_ := $(if \
-	$(shell go version | grep $(1)), \
-	@echo "", \
-	$(error "must be running Go version $(1)"))
+_ := $(if  \
+		$(shell  \
+			expr >/dev/null  \
+				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f2`  \
+				\>= `echo $(1) | cut -d. -f2`  \
+				\&  \
+				`go version | cut -d" " -f3 | cut -c3- | cut -d. -f1`  \
+				= `echo $(1) | cut -d. -f1`  \
+			&& echo 1),  \
+		@echo "",  \
+		$(error must be running Go version ^$(1) - you are running $(shell go version | cut -d" " -f3 | cut -c3-)))
 endef
 
 export GO15VENDOREXPERIMENT=1


### PR DESCRIPTION
Before we were writing all logs generated here into a file, which makes it hard to see errors without going into a machine and looking at files. Especially "catastrophic" errors that crash the process.

This PR changes it so that most logs generated go to stderr, but in the case where we re-emit log lines we write to the file. This should make it easier to debug failures.