### PR TITLE
fix lambda -> rsyslog message conversion to always have a task ID

### DIFF
--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -164,6 +164,8 @@ func splitAWSLambda(b LogEventBatch) ([]RSysLogMessage, bool) {
 		var task string
 		if matches := awsLambdaRequestIDRegex.FindAllString(event.Message, 1); len(matches) == 1 {
 			task = matches[0]
+		} else {
+			task = taskCruft // rsyslog message must contain a non-empty task ID to satisfy later parsing
 		}
 		out = append(out, RSysLogMessage{
 			Timestamp:   event.Timestamp.Time(),

--- a/splitter/splitter_test.go
+++ b/splitter/splitter_test.go
@@ -144,12 +144,18 @@ func TestSplitLambda(t *testing.T) {
 				Timestamp: NewUnixTimestampMillis(1498519943285),
 				Message:   `{"aws_request_id":"8edbd53f-64c7-4a3c-bf1e-efeff40f6512","level":"info","source":"app","title":"some-log-title"}`,
 			},
+			{
+				ID:        "99999992387663833181953011865369295871402094815542181889",
+				Timestamp: NewUnixTimestampMillis(1498519943285),
+				Message:   `Example message that doesn't contain a request ID`,
+			},
 		},
 	}
 	lines := Split(input)
 	expected := [][]byte{
 		[]byte(`2017-06-26T23:32:23.285001+00:00 aws-lambda env--app/arn%3Aaws%3Aecs%3Aus-east-1%3A999988887777%3Atask%2F8edbd53f-64c7-4a3c-bf1e-efeff40f6512[1]: START RequestId: 8edbd53f-64c7-4a3c-bf1e-efeff40f6512 Version: 3`),
 		[]byte(`2017-06-26T23:32:23.285001+00:00 aws-lambda env--app/arn%3Aaws%3Aecs%3Aus-east-1%3A999988887777%3Atask%2F8edbd53f-64c7-4a3c-bf1e-efeff40f6512[1]: {"aws_request_id":"8edbd53f-64c7-4a3c-bf1e-efeff40f6512","level":"info","source":"app","title":"some-log-title"}`),
+		[]byte(`2017-06-26T23:32:23.285001+00:00 aws-lambda env--app/arn%3Aaws%3Aecs%3Aus-east-1%3A999988887777%3Atask%2F12345678-1234-1234-1234-555566667777[1]: Example message that doesn't contain a request ID`),
 	}
 	assert.Equal(t, expected, lines)
 }


### PR DESCRIPTION
Before this change, logs that didn't contain a lambda request ID would be given an empty rsylog "task" field, which made our rsyslog message decoding regex fail. Example log line without a lambda request ID: https://dev-infra--haproxy-logs.int.clever.com/_plugin/kibana/#/discover?_a=(columns:!(rawlog),index:%5Blogs-%5DYYYY-MM-DD,interval:auto,query:(query_string:(analyze_wildcard:!t,lowercase_expanded_terms:!f,query:'%22ContainerInstanceARN%20for%20EcsInstanceID%22')),sort:!(timestamp,desc))&_g=(refreshInterval:(display:Off,pause:!f,section:0,value:0),time:(from:'2018-03-06T00:47:55.085Z',mode:absolute,to:'2018-03-06T00:47:55.235Z'))

This PR adds a task ID even when we can't find one