### PR TITLE
Fix shutdown requested

### DIFF
--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -51,6 +51,12 @@ func (srp *sampleRecordProcessor) ProcessRecords(records []kcl.Record) error {
 	return nil
 }
 
+func (srp *sampleRecordProcessor) ShutdownRequested() error {
+	fmt.Fprintf(os.Stderr, "Got shutdown requested, attempt to checkpoint.\n")
+	srp.checkpointer.Shutdown()
+	return nil
+}
+
 func (srp *sampleRecordProcessor) Shutdown(reason string) error {
 	if reason == "TERMINATE" {
 		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -62,11 +62,6 @@ func (srp *sampleRecordProcessor) Shutdown(reason string) error {
 }
 
 func main() {
-	f, err := os.Create("/tmp/kcl_stderr")
-	if err != nil {
-		panic(err)
-	}
-	defer f.Close()
 	kclProcess := kcl.New(os.Stdin, os.Stdout, os.Stderr, newSampleRecordProcessor())
 	kclProcess.Run()
 }

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -51,15 +51,12 @@ func (srp *sampleRecordProcessor) ProcessRecords(records []kcl.Record) error {
 	return nil
 }
 
-func (srp *sampleRecordProcessor) ShutdownRequested() error {
-	fmt.Fprintf(os.Stderr, "Got shutdown requested, attempt to checkpoint.\n")
-	srp.checkpointer.Shutdown()
-	return nil
-}
-
 func (srp *sampleRecordProcessor) Shutdown(reason string) error {
 	if reason == "TERMINATE" {
 		fmt.Fprintf(os.Stderr, "Was told to terminate, will attempt to checkpoint.\n")
+		srp.checkpointer.Shutdown()
+	} else if reason == "SHUTDOWN_REQUESTED" {
+		fmt.Fprintf(os.Stderr, "Got shutdown requested, attempt to checkpoint.\n")
 		srp.checkpointer.Shutdown()
 	} else {
 		fmt.Fprintf(os.Stderr, "Shutting down due to failover. Will not checkpoint.\n")


### PR DESCRIPTION
Message type shutdownRequested doesn't have `reason`, which causes checkpoint on termination not work.
This commit is to ask KCL daemon to checkpoint on shutdownRequested.