### PR TITLE
fix incompatible Record struct in KCL v2

### DIFF
--- a/kcl/kcl.go
+++ b/kcl/kcl.go
@@ -59,11 +59,13 @@ type ActionInitialize struct {
 }
 
 type Record struct {
-	SequenceNumber              string `json:"sequenceNumber"`
-	SubSequenceNumber           int    `json:"subSequenceNumber"`
-	ApproximateArrivalTimestamp int    `json:"approximateArrivalTimestamp"`
-	PartitionKey                string `json:"partitionKey"`
-	Data                        string `json:"data"`
+	SequenceNumber    string `json:"sequenceNumber"`
+	SubSequenceNumber int    `json:"subSequenceNumber"`
+	PartitionKey      string `json:"partitionKey"`
+	Data              string `json:"data"`
+	// KCL v2 has a different format, causing failure when json.Unmarshal.
+	// This is not used anywhere currently, so commenting it out.
+	//ApproximateArrivalTimestamp int    `json:"approximateArrivalTimestamp"`
 }
 
 type ActionProcessRecords struct {


### PR DESCRIPTION
For reference, an example of the data I got from KCL v2:
`{"approximateArrivalTimestamp":{"epochSecond":1539850614,"nano":289000000}}`