### PR TITLE
adding 'container_region' to kvmeta

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Clever/syslogparser"
-  packages = [".","rfc3164"]
+  packages = [
+    ".",
+    "rfc3164"
+  ]
   revision = "fb28ad3e4340c046323b7beba685a72fd12ecbe8"
 
 [[projects]]
@@ -25,7 +28,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -57,7 +63,11 @@
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  packages = [".","logger","router"]
+  packages = [
+    ".",
+    "logger",
+    "router"
+  ]
   revision = "096364e316a52652d3493be702d8105d8d01db84"
   version = "v6.6.0"
 
@@ -69,6 +79,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "12add425987f6b506139be39923e5dababe3a0337b5d8f81bf5722c55c58b52e"
+  inputs-digest = "4699293f3632dd38561ff60477aa7cc1ecaadc5808b974d017099e2189679286"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -243,6 +243,7 @@ func TestParseAndEnhance(t *testing.T) {
 				"env":              "deploy-env",
 				"container_env":    "env",
 				"container_app":    "app",
+				"container_region": "us-west-1",
 				"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 			},
 			ExpectedError: nil,
@@ -262,6 +263,7 @@ func TestParseAndEnhance(t *testing.T) {
 				"env":              "deploy-env",
 				"container_env":    "env",
 				"container_app":    "force-app",
+				"container_region": "us-west-1",
 				"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 			},
 			ExpectedError: nil,
@@ -278,6 +280,7 @@ func TestParseAndEnhance(t *testing.T) {
 				"decoder_msg_type": "syslog",
 				"container_env":    "env",
 				"container_app":    "app",
+				"container_region": "us-west-1",
 				"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 			},
 			ExpectedError: nil,
@@ -303,6 +306,7 @@ func TestParseAndEnhance(t *testing.T) {
 				"env":              "deploy-env",
 				"container_env":    "env",
 				"container_app":    "app",
+				"container_region": "us-west-1",
 				"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 				"nested":           map[string]interface{}{"a": "b"},
 			},
@@ -341,57 +345,73 @@ func TestGetContainerMeta(t *testing.T) {
 
 	t.Log("Must have a programname to get container meta")
 	programname := ""
-	_, err := getContainerMeta(programname, "", "", "")
+	_, err := getContainerMeta(programname, "", "", "", "")
 	assert.Error(err)
 
 	t.Log("Can parse a programname")
 	programname = `env1--app2/arn%3Aaws%3Aecs%3Aus-west-1%3A589690932525%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef`
-	meta, err := getContainerMeta(programname, "", "", "")
+	meta, err := getContainerMeta(programname, "", "", "", "")
 	assert.NoError(err)
 	assert.Equal(map[string]string{
-		"container_env":  "env1",
-		"container_app":  "app2",
-		"container_task": "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
+		"container_env":    "env1",
+		"container_app":    "app2",
+		"container_region": "us-west-1",
+		"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 	}, meta)
 
 	t.Log("Can override just 'env'")
 	overrideEnv := "force-env"
-	meta, err = getContainerMeta(programname, overrideEnv, "", "")
+	meta, err = getContainerMeta(programname, overrideEnv, "", "", "")
 	assert.NoError(err)
 	assert.Equal(map[string]string{
-		"container_env":  overrideEnv,
-		"container_app":  "app2",
-		"container_task": "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
+		"container_env":    overrideEnv,
+		"container_app":    "app2",
+		"container_region": "us-west-1",
+		"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 	}, meta)
 
 	t.Log("Can override just 'app'")
 	overrideApp := "force-app"
-	meta, err = getContainerMeta(programname, "", overrideApp, "")
+	meta, err = getContainerMeta(programname, "", overrideApp, "", "")
 	assert.NoError(err)
 	assert.Equal(map[string]string{
-		"container_env":  "env1",
-		"container_app":  overrideApp,
-		"container_task": "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
+		"container_env":    "env1",
+		"container_app":    overrideApp,
+		"container_region": "us-west-1",
+		"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
+	}, meta)
+
+	t.Log("Can override just 'region'")
+	overrideRegion := "force-region"
+	meta, err = getContainerMeta(programname, "", "", overrideRegion, "")
+	assert.NoError(err)
+	assert.Equal(map[string]string{
+		"container_env":    "env1",
+		"container_app":    "app2",
+		"container_region": overrideRegion,
+		"container_task":   "abcd1234-1a3b-1a3b-1234-d76552f4b7ef",
 	}, meta)
 
 	t.Log("Can override just 'task'")
 	overrideTask := "force-task"
-	meta, err = getContainerMeta(programname, "", "", overrideTask)
+	meta, err = getContainerMeta(programname, "", "", "", overrideTask)
 	assert.NoError(err)
 	assert.Equal(map[string]string{
-		"container_env":  "env1",
-		"container_app":  "app2",
-		"container_task": overrideTask,
+		"container_env":    "env1",
+		"container_app":    "app2",
+		"container_region": "us-west-1",
+		"container_task":   overrideTask,
 	}, meta)
 
 	t.Log("Can override all fields")
 	programname = `env--app/arn%3Aaws%3Aecs%3Aus-west-1%3A999988887777%3Atask%2Fabcd1234-1a3b-1a3b-1234-d76552f4b7ef`
-	meta, err = getContainerMeta(programname, overrideEnv, overrideApp, overrideTask)
+	meta, err = getContainerMeta(programname, overrideEnv, overrideApp, overrideRegion, overrideTask)
 	assert.NoError(err)
 	assert.Equal(map[string]string{
-		"container_env":  overrideEnv,
-		"container_app":  overrideApp,
-		"container_task": overrideTask,
+		"container_env":    overrideEnv,
+		"container_app":    overrideApp,
+		"container_region": overrideRegion,
+		"container_task":   overrideTask,
 	}, meta)
 }
 


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-3590

We'll often want to know the region that a log is coming from in the pods world, e.g. for metrics (especially if we want to use Cloudwatch since the metrics will have to be in the same region as the corresponding alarm).

Turns out we already have the info in the logs, but let's separate it into its own field to make it easier to use.