### PR TITLE
INFRA-2885: Split slowquery logs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,7 +4,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/Clever/syslogparser"
-  packages = [".","rfc3164"]
+  packages = [
+    ".",
+    "rfc3164"
+  ]
   revision = "fb28ad3e4340c046323b7beba685a72fd12ecbe8"
 
 [[projects]]
@@ -25,7 +28,10 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -57,7 +63,11 @@
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
-  packages = [".","logger","router"]
+  packages = [
+    ".",
+    "logger",
+    "router"
+  ]
   revision = "096364e316a52652d3493be702d8105d8d01db84"
   version = "v6.6.0"
 
@@ -69,6 +79,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "12add425987f6b506139be39923e5dababe3a0337b5d8f81bf5722c55c58b52e"
+  inputs-digest = "4699293f3632dd38561ff60477aa7cc1ecaadc5808b974d017099e2189679286"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -197,6 +197,18 @@ func TestSyslogDecoding(t *testing.T) {
 			ExpectedError: nil,
 		},
 		Spec{
+			Title: "Parses Rsyslog_ FileFormat with simple log body for slowquery",
+			Input: `2017-06-26T23:32:23.285001+00:00 aws-rds production-aurora-test-db: Slow query: select * from table.`,
+			ExpectedOutput: map[string]interface{}{
+				"timestamp":        logTime,
+				"hostname":         "aws-rds",
+				"programname":      "production-aurora-test-db",
+				"rawlog":           "Slow query: select * from table.",
+				"decoder_msg_type": "syslog",
+			},
+			ExpectedError: nil,
+		},
+		Spec{
 			Title:          "Fails to parse non-RSyslog log line",
 			Input:          `not rsyslog`,
 			ExpectedOutput: map[string]interface{}{},

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -198,9 +198,9 @@ func TestSyslogDecoding(t *testing.T) {
 		},
 		Spec{
 			Title: "Parses Rsyslog_ FileFormat with simple log body for slowquery",
-			Input: `2017-06-26T23:32:23.285001+00:00 aws-rds production-aurora-test-db: Slow query: select * from table.`,
+			Input: `2017-04-05T21:57:46.794862+00:00 aws-rds production-aurora-test-db: Slow query: select * from table.`,
 			ExpectedOutput: map[string]interface{}{
-				"timestamp":        logTime,
+				"timestamp":        logTime3,
 				"hostname":         "aws-rds",
 				"programname":      "production-aurora-test-db",
 				"rawlog":           "Slow query: select * from table.",

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -221,7 +221,6 @@ func splitAWSRDS(b LogEventBatch) ([]RSysLogMessage, bool) {
 		out = append(out, RSysLogMessage{
 			Timestamp:   event.Timestamp.Time(),
 			ProgramName: databaseName,
-			PID:         1,
 			Hostname:    "aws-rds",
 			Message:     event.Message,
 		})

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -137,6 +137,9 @@ func (r RSysLogMessage) String() string {
 
 func splitAWSBatch(b LogEventBatch) []RSysLogMessage {
 	matches := awsBatchTaskRegex.FindAllStringSubmatch(b.LogStream, 1)
+	if len(matches) != 1 {
+		return nil
+	}
 	env := matches[0][1]
 	app := matches[0][2]
 	task := matches[0][3]

--- a/splitter/splitter_test.go
+++ b/splitter/splitter_test.go
@@ -242,7 +242,7 @@ func TestSplitRDS(t *testing.T) {
 	}
 	lines := Split(input)
 	expected := [][]byte{
-		[]byte(`2017-06-26T23:32:23.285001+00:00 aws-rds production-aurora-test-db[1]: Slow query: select * from table.`),
+		[]byte(`2017-06-26T23:32:23.285001+00:00 aws-rds production-aurora-test-db: Slow query: select * from table.`),
 	}
 	assert.Equal(t, expected, lines)
 	for _, line := range expected {


### PR DESCRIPTION
Split CloudWatch rds cluster slowquery logs. 
Refactor the splitting logic from an `if _, ok; ok ` to an `if else matches`.

Example log stream: https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logEventViewer:group=/aws/rds/cluster/clever-dev-aurora-test-db/slowquery;stream=clever-dev-aurora-test-db;start=2019-08-20T18:06:19Z

