### PR TITLE
Fix regex that parses the RDS slowquery user

### DIFF
--- a/decode/decode.go
+++ b/decode/decode.go
@@ -107,7 +107,7 @@ func FieldsFromKayvee(line string) (map[string]interface{}, error) {
 	return m, nil
 }
 
-var userPattern = `#\sUser@Host:\s(?P<user>[a-zA-Z]+\[[a-zA-Z]+\])\s@\s[a-zA-Z]+.*Id:\s+(?P<id>[0-9]+)`
+var userPattern = `#\sUser@Host:\s(?P<user>[a-zA-Z]+\[[a-zA-Z]+\])\s@\s.*Id:\s+(?P<id>[0-9]+)`
 var userPatternRegex = regexp.MustCompile(userPattern)
 
 func FieldsFromRDSSlowquery(rawlog string) map[string]interface{} {

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -345,7 +345,7 @@ func TestParseAndEnhance(t *testing.T) {
 			},
 		},
 		ParseAndEnhanceSpec{
-			Title: "RDS Slowquery Log",
+			Title: "RDS Slowquery Log rdsadmin",
 			Line: `2017-04-05T21:57:46+00:00 aws-rds production-aurora-test-db: Slow query: # Time: 190921 16:02:59
 # User@Host: rdsadmin[rdsadmin] @ localhost []  Id:     1
 # Query_time: 22.741550  Lock_time: 0.000000 Rows_sent: 0  Rows_examined: 0SET timestamp=1569081779;call action start_seamless_scaling('AQEAAB1P/PAIqvTHEQFJAEkojZUoH176FGJttZ62JF5QmRehaf0S0VFTa+5MPJdYQ9k0/sekBlnMi8U=', 300000, 2);
@@ -359,6 +359,24 @@ SET timestamp=1569862702;`,
 				"timestamp":        logTime2,
 				"user":             "rdsadmin[rdsadmin]",
 				"user_id":          "1",
+			},
+		},
+		ParseAndEnhanceSpec{
+			Title: "RDS Slowquery Log clever user",
+			Line: `2017-04-05T21:57:46+00:00 aws-rds production-aurora-test-db: Slow query: # Time: 190921 16:02:59
+# User@Host: clever[clever] @ [10.1.11.112] Id: 868
+# Query_time: 2.000270 Lock_time: 0.000000 Rows_sent: 1 Rows_examined: 0
+SET timestamp=1571090308;
+select sleep(2);`,
+			ExpectedOutput: map[string]interface{}{
+				"env":              "deploy-env",
+				"hostname":         "aws-rds",
+				"programname":      "production-aurora-test-db",
+				"decoder_msg_type": "syslog",
+				"rawlog":           "Slow query: # Time: 190921 16:02:59\n# User@Host: clever[clever] @ [10.1.11.112] Id: 868\n# Query_time: 2.000270 Lock_time: 0.000000 Rows_sent: 1 Rows_examined: 0\nSET timestamp=1571090308;\nselect sleep(2);",
+				"timestamp":        logTime2,
+				"user":             "clever[clever]",
+				"user_id":          "868",
 			},
 		},
 	}


### PR DESCRIPTION
User line for slowquery logs:

1. `# User@Host: clever[clever] @ [10.1.11.112] Id: 868`
2. `# User@Host: rdsadmin[rdsadmin] @ localhost [] Id: 1`

The previous regex did not account for 1st case. Just greedily match
