### PR TITLE
support parsing AWS Glue job logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Clever/eng-infra

--- a/decode/decode.go
+++ b/decode/decode.go
@@ -448,7 +448,7 @@ func ParseAndEnhance(line string, env string) (map[string]interface{}, error) {
 
 const containerMeta = `([a-z0-9-]+)--([a-z0-9-]+)\/` + // env--app
 	`arn%3Aaws%3Aecs%3Aus-(west|east)-[1-2]%3A[0-9]{12}%3Atask%2F` + // ARN cruft
-	`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[a-z0-9]{32})` // task-id (ECS, both EC2 and Fargate)
+	`([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[a-z0-9]{32}|jr_[a-z0-9-]+)` // task-id (ECS, both EC2 and Fargate), Glue Job ID
 
 var containerMetaRegex = regexp.MustCompile(containerMeta)
 


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRANG-3968

parses AWS Glue job logs and fills in hostname, container_env, container_app, and container_task. Job ID is used as "container_task" which is consistent with how we overload it elsewhere (e.g. lambda request ID).