### PR TITLE
Add zlib decompression to batch consumer.

### DIFF
--- a/batchconsumer/writer.go
+++ b/batchconsumer/writer.go
@@ -62,7 +62,7 @@ func (b *batchedWriter) Initialize(shardID string, checkpointer kcl.Checkpointer
 
 func (b *batchedWriter) splitMessageIfNecessary(record []byte) ([][]byte, error) {
 	// We handle three types of records:
-	// - records emitted from CWLogs Subscription
+	// - records emitted from CWLogs Subscription (which are gzip compressed)
 	// - uncompressed records emitted from KPL
 	// - zlib compressed records (e.g. as compressed and emitted by Kinesis plugin for Fluent Bit)
 	if splitter.IsGzipped(record) {


### PR DESCRIPTION
This has become relevant as zlib is the compression method supported by the Kinesis plugin for Fluent Bit.

Besides the unit test, I additionally verified this against real logs by deploying an application to AWS Fargate using zlib compression as indicated in https://github.com/aws/amazon-kinesis-streams-for-fluent-bit. I obtained a log off of the kinesis stream using AWS CLI, base64 decoded it, then fed the log into Golang's `zlib` decoding: https://play.golang.com/p/8j1hybg2biR.