### PR TITLE
Refactor zlib decompression into the splitter package

### DIFF
--- a/batchconsumer/writer_test.go
+++ b/batchconsumer/writer_test.go
@@ -1,11 +1,7 @@
 package batchconsumer
 
 import (
-	"bytes"
-	"compress/gzip"
-	"compress/zlib"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -14,7 +10,6 @@ import (
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 
 	"github.com/Clever/amazon-kinesis-client-go/kcl"
-	"github.com/Clever/amazon-kinesis-client-go/splitter"
 )
 
 type ignoringSender struct{}
@@ -425,76 +420,4 @@ func TestStaggeredCheckpointing(t *testing.T) {
 	assert.Equal(2, len(mocksender.batches["tag3"][2]))
 	assert.Equal("tag3", string(mocksender.batches["tag3"][2][0]))
 	assert.Equal("tag3", string(mocksender.batches["tag3"][2][1]))
-}
-
-func TestSplitIfNecesary(t *testing.T) {
-
-	// We provide three different inputs to batchedWriter.splitMessageIfNecessary
-	// plain text
-	// zlib compressed text
-	// gzip compressed CloudWatch logs batch
-	// we verify that the split function matches the input against the correct splitter
-	// and decodes it.
-
-	assert := assert.New(t)
-
-	mockFailedLogsFile := logger.New("testing")
-	mockconfig := withDefaults(Config{
-		BatchInterval:  10 * time.Millisecond,
-		CheckpointFreq: 20 * time.Millisecond,
-	})
-
-	wrt := NewBatchedWriter(mockconfig, ignoringSender{}, mockFailedLogsFile)
-
-	plainTextInput := []byte("hello, world!")
-
-	records, err := wrt.splitMessageIfNecessary(plainTextInput)
-	assert.NoError(err)
-	assert.Equal(
-		records,
-		[][]byte{[]byte("hello, world!")},
-	)
-
-	var z bytes.Buffer
-	zbuf := zlib.NewWriter(&z)
-	zbuf.Write([]byte("hello, world!"))
-	zbuf.Close()
-	zlibSingleInput := z.Bytes()
-
-	records, err = wrt.splitMessageIfNecessary(zlibSingleInput)
-	assert.NoError(err)
-	assert.Equal(
-		records,
-		[][]byte{[]byte("hello, world!")},
-	)
-
-	// the details of this part aren't super important since the actual functionality is
-	// tested in the splitter package, we just want to make sure that OUR split function
-	// correctly realizes it's gzip and call the splitter package's functionality
-	var g bytes.Buffer
-	gbuf := gzip.NewWriter(&g)
-	cwLogBatch := splitter.LogEventBatch{
-		MessageType:         "test",
-		Owner:               "test",
-		LogGroup:            "test",
-		LogStream:           "test",
-		SubscriptionFilters: []string{""},
-		LogEvents: []splitter.LogEvent{{
-			ID:        "test",
-			Timestamp: splitter.UnixTimestampMillis(time.Date(2020, time.September, 9, 9, 10, 10, 0, time.UTC)),
-			Message:   "test",
-		}},
-	}
-	cwLogBatchJSON, _ := json.Marshal(cwLogBatch)
-	gbuf.Write(cwLogBatchJSON)
-	gbuf.Close()
-	gzipBatchInput := g.Bytes()
-
-	expectedRecord := []byte("2020-09-09T09:10:10.000001+00:00 test test--test/arn%3Aaws%3Aecs%3Aus-east-1%3A999988887777%3Atask%2F12345678-1234-1234-1234-555566667777: test")
-	records, err = wrt.splitMessageIfNecessary(gzipBatchInput)
-	assert.NoError(err)
-	assert.Equal(
-		records,
-		[][]byte{expectedRecord},
-	)
 }


### PR DESCRIPTION
Being in the batchconsumer package means it will work for anything
using KCL, but lambdas that subscribe to these log streams do not use
batchconsumer at all; instead they invoke the splitter package
directly. As such, if we want this functionality to be available to
lambda log consumers, it can't be in batchconsumer.

There are no functionality changes here, just moving code from an
unexported method in one place to an exported function in another
place. The tests also get moved along with it.

For example, you can see that there is (Clever-private) code 
duplication [here](https://github.com/Clever/kinesis-log-archives-consumer/blob/master/cmd/handler/handler.go#L266-L277). After this change, that can be replaced with a call 
to the new `splitter.SplitMessageIfNecessary` function here.