### PR TITLE
Refactor decompression

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,6 +13,47 @@
   revision = "fb28ad3e4340c046323b7beba685a72fd12ecbe8"
 
 [[projects]]
+  digest = "1:ebf4bf0cc2e8705b66f67fecee8837e26c8b67a11ede9dd1f18a2841b6de5fac"
+  name = "github.com/a8m/kinesis-producer"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2b76ac68f594232c724b44643c6994768d5a5f35"
+  version = "v0.2.0"
+
+[[projects]]
+  digest = "1:b597f05b10e1c62829891fc8110d4f8df9caaba70928eaaffeba182664ac190a"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/credentials",
+    "aws/endpoints",
+    "aws/request",
+    "aws/signer/v4",
+    "internal/context",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkmath",
+    "internal/sdkrand",
+    "internal/shareddefaults",
+    "internal/strings",
+    "internal/sync/singleflight",
+    "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/rest",
+    "service/kinesis",
+  ]
+  pruneopts = ""
+  revision = "416d69c754abe8f0b32f6dcd8837d086812583d6"
+  version = "v1.35.28"
+
+[[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -21,12 +62,35 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:6532affeeaaccdc6919d5773516176b77de02b4af8cf9a7fac16bae77aa319c5"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = ""
+  revision = "4846b58453b3708320bdb524f25cc5a1d9cda4d4"
+  version = "v1.4.3"
+
+[[projects]]
   branch = "master"
   digest = "1:c7a6f4f1e7baeabf4de954d2d7f82343252f9e66b40abf694687b1df6fbccd5e"
   name = "github.com/jeromer/syslogparser"
   packages = ["."]
   pruneopts = ""
   revision = "5fbaaf06d9e72f781d19c61e130ba63f4d6dab31"
+
+[[projects]]
+  digest = "1:13fe471d0ed891e8544eddfeeb0471fd3c9f2015609a1c000aefdedf52a19d40"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2b33e84"
+
+[[projects]]
+  digest = "1:ef0f9731bc6c3c59396adc50f36da36ca98c704812c449794f9326f7bc64b5f1"
+  name = "github.com/jpillora/backoff"
+  packages = ["."]
+  pruneopts = ""
+  revision = "8eab2debe79d12b7bd3d10653910df25fa9552ba"
+  version = "1.0.0"
 
 [[projects]]
   digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
@@ -80,6 +144,41 @@
   revision = "3af7569d3a1e776fc2a3c1cec133b43105ea9c2e"
 
 [[projects]]
+  digest = "1:0d049ff01749ce1d6092c85cb90a02dfdb3b401939b13415b7e608f36bc8ecee"
+  name = "google.golang.org/protobuf"
+  packages = [
+    "encoding/prototext",
+    "encoding/protowire",
+    "internal/descfmt",
+    "internal/descopts",
+    "internal/detrand",
+    "internal/encoding/defval",
+    "internal/encoding/messageset",
+    "internal/encoding/tag",
+    "internal/encoding/text",
+    "internal/errors",
+    "internal/fieldsort",
+    "internal/filedesc",
+    "internal/filetype",
+    "internal/flags",
+    "internal/genid",
+    "internal/impl",
+    "internal/mapsort",
+    "internal/pragma",
+    "internal/set",
+    "internal/strs",
+    "internal/version",
+    "proto",
+    "reflect/protoreflect",
+    "reflect/protoregistry",
+    "runtime/protoiface",
+    "runtime/protoimpl",
+  ]
+  pruneopts = ""
+  revision = "3f7a61f89bb6813f89d981d1870ed68da0b3c3f1"
+  version = "v1.25.0"
+
+[[projects]]
   digest = "1:0923ed679d96b9e53b8c43892e2094ebb5dccd0a66709b20c90f43c37ff71ff1"
   name = "gopkg.in/Clever/kayvee-go.v6"
   packages = [
@@ -113,6 +212,8 @@
   input-imports = [
     "github.com/Clever/syslogparser",
     "github.com/Clever/syslogparser/rfc3164",
+    "github.com/a8m/kinesis-producer",
+    "github.com/golang/protobuf/proto",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "golang.org/x/time/rate",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,3 +12,11 @@
 [[constraint]]
   name = "gopkg.in/Clever/kayvee-go.v6"
   version = "6.24.0"
+
+[[constraint]]
+  name = "github.com/a8m/kinesis-producer"
+  version = "v0.2.0"
+
+[[constraint]]
+  name = "github.com/golang/protobuf"
+  version = "v1.4.3"

--- a/splitter/splitter.go
+++ b/splitter/splitter.go
@@ -5,7 +5,7 @@
 // CloudWatch bundles. KCL automatically unbundles KPL aggregates before passing the records to the consumer.
 // Non-KCL applications (such as Lambdas consuming KPL-produced aggregates) should either use
 // - KPLDeaggregate if the consumer purely wants to unbundle KPL aggregates, but will handle the raw records themselves.
-// - DeaggregateAndSplitIfNecessary if the consumer wants to apply the same decompress and split logic as SplitMessageIfNecessary
+// - Deaggregate if the consumer wants to apply the same decompress and split logic as SplitMessageIfNecessary
 //   in addition to the KPL splitting.
 package splitter
 
@@ -65,7 +65,7 @@ func KPLDeaggregate(kinesisRecord []byte) ([][]byte, error) {
 	return records, nil
 }
 
-// DeaggregateAndSplitIfNecessary is a combination of KPLDeaggregate and SplitMessageIfNecessary
+// Deaggregate is a combination of KPLDeaggregate and SplitMessageIfNecessary
 // First it tries to KPL-deaggregate. If unsuccessful, it calls SplitIfNecessary on the original record.
 // If successful, it iterates over the individual user records and attempts to unzlib them.
 // If a record inside an aggregate is in zlib format, the output will contain the unzlibbed version.
@@ -75,7 +75,7 @@ func KPLDeaggregate(kinesisRecord []byte) ([][]byte, error) {
 // Also it lets us iterate over the user records one less time, since KPLDeaggregate loops over the records and we would need to loop again to unzlib.
 //
 // See the SplitMessageIfNecessary documentation for the format of output for CloudWatch log bundles.
-func DeaggregateAndSplitIfNecessary(kinesisRecord []byte) ([][]byte, error) {
+func Deaggregate(kinesisRecord []byte) ([][]byte, error) {
 	if !IsKPLAggregate(kinesisRecord) {
 		return SplitMessageIfNecessary(kinesisRecord)
 	}

--- a/splitter/splitter_test.go
+++ b/splitter/splitter_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	b64 "encoding/base64"
 	"encoding/json"
+	"os"
 	"testing"
 	"time"
 
@@ -16,6 +17,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestMain(m *testing.M) {
+	// In the conversion of CloudWatch LogEvent struct to an RSyslog struct to a string,
+	// the timezone used in the final string depends on the locally set timezone.
+	// in order for tests to pass, we set TZ to UTC
+	os.Setenv("TZ", "UTC")
+	os.Exit(m.Run())
+}
 
 func TestUnpacking(t *testing.T) {
 	input := "H4sIAAAAAAAAADWOTQuCQBRF/8ow6wj6ENRdhLXIClJoERKTvsZHOiPzxiLE/96YtTzcy72n4zUQCQnpuwEe8vXxkJ6O8XUfJclqG/EJ1y8FZkgq3RYvYfMy1pJcUGm5NbptXDZSYg2IekRqb5QbbCxqtcHKgiEeXrJvL3qCsgN2HIuxbtFpWFG7sdky8L1ZECwXc9+b/PUGgXPMfnrspxeydQn5A5VkJYjKlkzfWeGWUInhme1QASEx+qpNeZ/1H1PFPn3yAAAA"
@@ -289,7 +298,6 @@ func TestSplitGlue(t *testing.T) {
 	}
 }
 
-// If running this test directly with `go test`, it may fail unless you set the env var TZ=UTC
 func TestSplitIfNecesary(t *testing.T) {
 
 	// We provide three different inputs to batchedWriter.splitMessageIfNecessary
@@ -384,7 +392,6 @@ func createKPLAggregate(input [][]byte, compress bool) []byte {
 	return append(log, logHash[0:16]...)
 }
 
-// If running this test directly with `go test`, it may fail unless you set the env var TZ=UTC
 func TestKPLDeaggregate(t *testing.T) {
 	type test struct {
 		description string
@@ -441,7 +448,6 @@ func TestKPLDeaggregate(t *testing.T) {
 	}
 }
 
-// If running this test directly with `go test`, it may fail unless you set the env var TZ=UTC
 func TestDeaggregateAndSplit(t *testing.T) {
 	type test struct {
 		description string

--- a/splitter/splitter_test.go
+++ b/splitter/splitter_test.go
@@ -448,7 +448,7 @@ func TestKPLDeaggregate(t *testing.T) {
 	}
 }
 
-func TestDeaggregateAndSplit(t *testing.T) {
+func TestDeaggregate(t *testing.T) {
 	type test struct {
 		description string
 		input       []byte
@@ -542,7 +542,7 @@ func TestDeaggregateAndSplit(t *testing.T) {
 	})
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			out, err := DeaggregateAndSplitIfNecessary(tt.input)
+			out, err := Deaggregate(tt.input)
 
 			if tt.shouldError {
 				assert.Error(t, err)


### PR DESCRIPTION
Add functionality for handling KPL aggregates and KPL aggregated plus zlibbed logs.

This PR adds a lowest-common-denominator function, KPLDeaggregate, for handling records that might be KPL aggregated. All it does is turn one bytestring into a slice of bytestrings. It also adds a function, DeaggregateAndSplitIfNecessary, to wrap the existing functionality of SplitMessageIfNecessary with KPL deaggreation (it's a bit more convenient then calling one then the other, since if you called them in sequence you'd have to loop over the result of the KPL deggregation and apply Split to each one).

These functions are handy for non-KCL consumers, like Lambda functions. KCL automatically applies deaggreation for you.

This change is backwards compatible - the previously exposed function SplitMessageIfNecessary still does the same things.

# Testing

Besides the tests added here, I also deployed one of Clever's log-stream-processing lambdas to read from a kinesis stream, and deployed an app to log to that stream using Fluent Bit set to do aggregation plus zlib. 
