### PR TITLE
[INFRANG-6876] Upgrade to go 1.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/Clever/amazon-kinesis-client-go
+    working_directory: ~/go/src/github.com/Clever/amazon-kinesis-client-go
     docker:
-    - image: cimg/go:1.24-stretch
+    - image: cimg/go:1.24
     - image: circleci/mongo:3.2.20-jessie-ram
     environment:
       GOPRIVATE: github.com/Clever/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/amazon-kinesis-client-go
     docker:
-    - image: circleci/golang:1.13-stretch
+    - image: cimg/go:1.24-stretch
     - image: circleci/mongo:3.2.20-jessie-ram
     environment:
       GOPRIVATE: github.com/Clever/*

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ include golang.mk
 .DEFAULT_GOAL := test # override default goal set in library makefile
 
 SHELL := /bin/bash
-PKG := github.com/Clever/amazon-kinesis-client-go
 PKGS := $(shell go list ./... | grep -v /vendor )
 .PHONY: download_jars run build
 $(eval $(call golang-version-check,1.24))
@@ -43,7 +42,7 @@ download_jars:
 all: test build
 
 build:
-	CGO_ENABLED=0 go build -installsuffix cgo -o build/$(CONSUMER) $(PKG)/cmd/$(CONSUMER)
+	CGO_ENABLED=0 go build -installsuffix cgo -o build/$(CONSUMER) ./cmd/$(CONSUMER)
 
 run: build download_jars
 	command -v java >/dev/null 2>&1 || { echo >&2 "Java not installed. Install java!"; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/amazon-kinesis-client-go
 PKGS := $(shell go list ./... | grep -v /vendor )
 .PHONY: download_jars run build
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.24))
 
 CONSUMER ?= consumer
 TMP_DIR := ./tmp-jars

--- a/decode/decode_test.go
+++ b/decode/decode_test.go
@@ -100,7 +100,7 @@ func TestKayveeDecoding(t *testing.T) {
 	}
 
 	for _, spec := range specs {
-		t.Run(fmt.Sprintf(spec.Title), func(t *testing.T) {
+		t.Run(fmt.Sprint(spec.Title), func(t *testing.T) {
 			assert := assert.New(t)
 			fields, err := FieldsFromKayvee(spec.Input)
 			if spec.ExpectedError != nil {
@@ -217,7 +217,7 @@ func TestSyslogDecoding(t *testing.T) {
 		},
 	}
 	for _, spec := range specs {
-		t.Run(fmt.Sprintf(spec.Title), func(t *testing.T) {
+		t.Run(fmt.Sprint(spec.Title), func(t *testing.T) {
 			assert := assert.New(t)
 			fields, err := FieldsFromSyslog(spec.Input)
 			if spec.ExpectedError != nil {
@@ -542,7 +542,7 @@ select sleep(2);`,
 		},
 	}
 	for _, spec := range specs {
-		t.Run(fmt.Sprintf(spec.Title), func(t *testing.T) {
+		t.Run(fmt.Sprint(spec.Title), func(t *testing.T) {
 			assert := assert.New(t)
 			fields, err := ParseAndEnhance(spec.Line, "deploy-env")
 			if spec.ExpectedError != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,21 +1,28 @@
 module github.com/amazon-kinesis-client-go
 
-go 1.13
+go 1.24
 
 require (
 	github.com/Clever/amazon-kinesis-client-go v1.0.0
 	github.com/Clever/syslogparser v0.0.0-20170816194131-fb28ad3e4340
 	github.com/a8m/kinesis-producer v0.2.0
-	github.com/aws/aws-sdk-go v1.35.28 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2
-	github.com/jeromer/syslogparser v0.0.0-20190429161531-5fbaaf06d9e7 // indirect
-	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d // indirect
 	github.com/stretchr/testify v1.7.0
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonschema v1.2.1-0.20200424115421-065759f9c3d7 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gopkg.in/Clever/kayvee-go.v6 v6.24.1
+)
+
+require (
+	github.com/aws/aws-sdk-go v1.35.28 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jeromer/syslogparser v0.0.0-20190429161531-5fbaaf06d9e7 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.1-0.20200424115421-065759f9c3d7 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
 	gopkg.in/yaml.v2 v2.3.1-0.20200602174213-b893565b90ca // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	launchpad.net/gocheck v0.0.0-20140225173054-000000000087 // indirect

--- a/golang.mk
+++ b/golang.mk
@@ -1,7 +1,7 @@
 # This is the default Clever Golang Makefile.
 # It is stored in the dev-handbook repo, github.com/Clever/dev-handbook
 # Please do not alter this file directly.
-GOLANG_MK_VERSION := 1.0.0
+GOLANG_MK_VERSION := 1.3.1
 
 SHELL := /bin/bash
 SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
@@ -11,7 +11,7 @@ SYSTEM := $(shell uname -a | cut -d" " -f1 | tr '[:upper:]' '[:lower:]')
 export TZ=UTC
 
 # go build flags for use across all commands which accept them
-GO_BUILD_FLAGS := "-mod=vendor"
+export GOFLAGS := -mod=vendor $(GOFLAGS)
 
 # if the gopath includes several directories, use only the first
 GOPATH=$(shell echo $$GOPATH | cut -d: -f1)
@@ -39,7 +39,7 @@ endef
 # so we're defended against it breaking or changing in the future.
 FGT := $(GOPATH)/bin/fgt
 $(FGT):
-	go get github.com/GeertJohan/fgt@262f7b11eec07dc7b147c44641236f3212fee89d
+	go install -mod=readonly github.com/GeertJohan/fgt@262f7b11eec07dc7b147c44641236f3212fee89d
 
 golang-ensure-curl-installed:
 	@command -v curl >/dev/null 2>&1 || { echo >&2 "curl not installed. Please install curl."; exit 1; }
@@ -47,9 +47,11 @@ golang-ensure-curl-installed:
 # Golint is a tool for linting Golang code for common errors.
 # We pin its version because an update could add a new lint check which would make
 # previously passing tests start failing without changing our code.
+# this package is deprecated and frozen
+# Infra recommendation is to eventually move to https://github.com/golangci/golangci-lint so don't fail on linting error for now
 GOLINT := $(GOPATH)/bin/golint
 $(GOLINT):
-	go get golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
+	go install -mod=readonly golang.org/x/lint/golint@738671d3881b9731cc63024d5d88cf28db875626
 
 # golang-fmt-deps requires the FGT tool for checking output
 golang-fmt-deps: $(FGT)
@@ -74,14 +76,6 @@ endef
 # golang-lint-deps-strict requires the golint tool for golang linting.
 golang-lint-deps-strict: $(GOLINT) $(FGT)
 
-# golang-lint-strict calls golint on all golang files in the pkg and fails if any lint
-# errors are found.
-# arg1: pkg path
-define golang-lint-strict
-@echo "LINTING $(1)..."
-@PKG_PATH=$$(go list -f '{{.Dir}}' $(1)); find $${PKG_PATH}/*.go -type f | grep -v gen_ | xargs $(FGT) $(GOLINT)
-endef
-
 # golang-test-deps is here for consistency
 golang-test-deps:
 
@@ -89,7 +83,7 @@ golang-test-deps:
 # arg1: pkg path
 define golang-test
 @echo "TESTING $(1)..."
-@go test $(GO_BUILD_FLAGS) -v $(1)
+@go test -v $(1)
 endef
 
 # golang-test-strict-deps is here for consistency
@@ -99,7 +93,22 @@ golang-test-strict-deps:
 # arg1: pkg path
 define golang-test-strict
 @echo "TESTING $(1)..."
-@go test -v $(GO_BUILD_FLAGS) -race $(1)
+@go test -v -race $(1)
+endef
+
+# golang-test-strict-cover-deps is here for consistency
+golang-test-strict-cover-deps:
+
+# golang-test-strict-cover uses the Go toolchain to run all tests in the pkg with the race and cover flag.
+# appends coverage results to coverage.txt
+# arg1: pkg path
+define golang-test-strict-cover
+@echo "TESTING $(1)..."
+@go test -v -race -cover -coverprofile=profile.tmp -covermode=atomic $(1)
+@if [ -f profile.tmp ]; then \
+  cat profile.tmp | tail -n +2 >> coverage.txt; \
+  rm profile.tmp; \
+fi;
 endef
 
 # golang-vet-deps is here for consistency
@@ -109,7 +118,7 @@ golang-vet-deps:
 # arg1: pkg path
 define golang-vet
 @echo "VETTING $(1)..."
-@go vet $(GO_BUILD_FLAGS) $(1)
+@go vet $(1)
 endef
 
 # golang-test-all-deps installs all dependencies needed for different test cases.
@@ -132,23 +141,51 @@ golang-test-all-strict-deps: golang-fmt-deps golang-lint-deps-strict golang-test
 # arg1: pkg path
 define golang-test-all-strict
 $(call golang-fmt,$(1))
-$(call golang-lint-strict,$(1))
+$(call golang-lint,$(1))
 $(call golang-vet,$(1))
 $(call golang-test-strict,$(1))
 endef
 
-# golang-build: builds a golang binary. ensures CGO build is done during CI. This is needed to make a binary that works with a Docker alpine image.
+# golang-test-all-strict-cover-deps: installs all dependencies needed for different test cases.
+golang-test-all-strict-cover-deps: golang-fmt-deps golang-lint-deps-strict golang-test-strict-cover-deps golang-vet-deps
+
+# golang-test-all-strict-cover calls fmt, lint, vet and test on the specified pkg with strict and cover
+# requirements that no errors are thrown while linting.
+# arg1: pkg path
+define golang-test-all-strict-cover
+$(call golang-fmt,$(1))
+$(call golang-lint,$(1))
+$(call golang-vet,$(1))
+$(call golang-test-strict-cover,$(1))
+endef
+
+# golang-build: builds a golang binary
 # arg1: pkg path
 # arg2: executable name
 define golang-build
-@echo "BUILDING..."
-@if [ -z "$$CI" ]; then \
-	go build $(GO_BUILD_FLAGS) -o bin/$(2) $(1); \
-else \
-	echo "-> Building CGO binary"; \
-	CGO_ENABLED=0 go build $(GO_BUILD_FLAGS) -installsuffix cgo -o bin/$(2) $(1); \
-fi;
+@echo "BUILDING $(2)..."
+@CGO_ENABLED=0 go build -o bin/$(2) $(1);
 endef
+
+# golang-debug-build: builds a golang binary with debugging capabilities
+# arg1: pkg path
+# arg2: executable name
+define golang-debug-build
+@echo "BUILDING $(2) FOR DEBUG..."
+@CGO_ENABLED=0 go build -gcflags="all=-N -l" -o bin/$(2) $(1);
+endef
+
+# golang-cgo-build: builds a golang binary with CGO
+# arg1: pkg path
+# arg2: executable name
+define golang-cgo-build
+@echo "BUILDING $(2) WITH CGO ..."
+@CGO_ENABLED=1 go build -installsuffix cgo -o bin/$(2) $(1);
+endef
+
+# golang-setup-coverage: set up the coverage file
+golang-setup-coverage:
+	@echo "mode: atomic" > coverage.txt
 
 # golang-update-makefile downloads latest version of golang.mk
 golang-update-makefile:


### PR DESCRIPTION
<!-- This template should be used as a living PR template for future go migrations -->

# JIRA
https://clever.atlassian.net/browse/INFRANG-6876

# About
This PR upgrades this repo to Go version 1.24. See the [release notes](https://tip.golang.org/doc/go1.24) for full details.

It performs the following changes:
1. Upgrade the module to 1.24.
2. Upgrade the golang.mk file to the latest version.
3. Replaces any `tools.go` file with the new go.mod tools directive.
4. Updates any circle CI build images to 1.24.
5. Updates the go version check in the makefile.
6. Updates any debian docker images to a version with a glibc compatible with the CI build image.



#### New Go Vet Check
Go vet in 1.24 introduces a new check which catches non-constant format strings in calls to printf functions. This has a tendency to find bugs in existing code, however the fix is pretty strait forward should your CI begin to fail. You can see more details in the official issue https://github.com/golang/go/issues/60529. If your CI fails because of this, you may add an extra commit resolving the issue, then merge. The microplane script attempts to resolve as many of these cases as possible automatically.

# Testing
Go version upgrades have historically been extremely stable. The only exception has been incompatible glibc versions which have been tested for in workers before merging. All standard CI testing is also performed before merging.

# Problems Upgrading?
Checkout this [google doc](https://docs.google.com/document/d/1ctg3eT8zkKHXqsf7CCUBB77ERmEVMsyZoYAIxXm19hs/edit?usp=sharing) for knowledge sharing any problems you encounter during upgrades!
